### PR TITLE
Update GPT 4 and 3.5 turbo models to 0125

### DIFF
--- a/.changeset/breezy-pets-yawn.md
+++ b/.changeset/breezy-pets-yawn.md
@@ -1,0 +1,5 @@
+---
+"syncia": patch
+---
+
+Update GPT 4 and 3.5 turbo models to 0125

--- a/src/config/settings/index.ts
+++ b/src/config/settings/index.ts
@@ -8,9 +8,9 @@ export enum ThemeOptions {
 
 export enum AvailableModels {
   GPT_4_VISION = 'gpt-4-vision-preview',
-  GPT_4_TURBO = 'gpt-4-1106-preview',
+  GPT_4_TURBO = 'gpt-4-0125-preview',
   GPT_4 = 'gpt-4',
-  GPT_3_5_TURBO = 'gpt-3.5-turbo-1106',
+  GPT_3_5_TURBO = 'gpt-3.5-turbo-0125',
 }
 
 export enum Mode {


### PR DESCRIPTION
Update the GPT 4 Turbo and GPT 3.5 Turbo model references to the latest ones (0125), released on January 25th, 2024.

Relevant docs/posts:
- January 25th, 2024 OpenAI blog post: [New embedding models and API updates](https://openai.com/blog/new-embedding-models-and-api-updates)
- [OpenAI Models docs](https://platform.openai.com/docs/models)

Resolves https://github.com/Royal-lobster/Syncia/issues/55