### PR TITLE
openAI project apikey input

### DIFF
--- a/src/components/Sidebar/auth/index.tsx
+++ b/src/components/Sidebar/auth/index.tsx
@@ -59,7 +59,7 @@ const Auth = () => {
         placeholder="Enter your OpenAI API key"
         data-error={error ? 'true' : undefined}
         className="cdx-mt-4 cdx-text-center cdx-p-2 cdx-w-full cdx-rounded-md cdx-border dark:cdx-border-neutral-600 cdx-border-neutral-200 dark:cdx-bg-neutral-800/90 cdx-bg-neutral-200/90 focus:cdx-outline-none focus:cdx-ring-2 focus:cdx-ring-blue-900 focus:cdx-ring-opacity-50 data-[error]:cdx-text-red-500"
-        pattern="sk-[a-zA-Z0-9]{48}"
+        pattern="sk-[a-zA-Z0-9]+"
       />
 
       {error && (


### PR DESCRIPTION
OpenAI has a project key whose length is different from the user key. In my account, I have a project key that is 56 characters long. I am unable to submit my project key due to the current input check.
<img width="1007" alt="image" src="https://github.com/Royal-lobster/Syncia/assets/23279667/d6b40efc-df5c-41f3-a420-b180931b8eaf">
