### PR TITLE
openAI project apikey input

### DIFF
--- a/.changeset/violet-pigs-pull.md
+++ b/.changeset/violet-pigs-pull.md
@@ -1,0 +1,5 @@
+---
+"syncia": patch
+---
+
+openAI project apikey input on welcome screen

--- a/src/components/Sidebar/auth/index.tsx
+++ b/src/components/Sidebar/auth/index.tsx
@@ -59,7 +59,7 @@ const Auth = () => {
         placeholder="Enter your OpenAI API key"
         data-error={error ? 'true' : undefined}
         className="cdx-mt-4 cdx-text-center cdx-p-2 cdx-w-full cdx-rounded-md cdx-border dark:cdx-border-neutral-600 cdx-border-neutral-200 dark:cdx-bg-neutral-800/90 cdx-bg-neutral-200/90 focus:cdx-outline-none focus:cdx-ring-2 focus:cdx-ring-blue-900 focus:cdx-ring-opacity-50 data-[error]:cdx-text-red-500"
-        pattern="sk-[a-zA-Z0-9]{48}"
+        pattern="sk-(proj-)?[a-zA-Z0-9]{48}"
       />
 
       {error && (


### PR DESCRIPTION
OpenAI has a project key whose length is different from the user key. In my account, I have a project key that is 56 characters long. I am unable to submit my project key due to the current input check.

<img width="991" alt="image" src="https://github.com/Royal-lobster/Syncia/assets/23279667/abec614d-f46c-42c8-ac46-b5e402e6c562">
