### PR TITLE
Fix Stop button not working

### DIFF
--- a/.changeset/popular-roses-train.md
+++ b/.changeset/popular-roses-train.md
@@ -1,0 +1,5 @@
+---
+"syncia": patch
+---
+
+Fix Stop button not working

--- a/src/hooks/useChatCompletion.ts
+++ b/src/hooks/useChatCompletion.ts
@@ -29,6 +29,8 @@ interface UseChatCompletionProps {
  *
  * And returns them along with useful state from useCurrentChat hook
  */
+let controller: AbortController
+
 export const useChatCompletion = ({
   model,
   apiKey,
@@ -71,10 +73,9 @@ export const useChatCompletion = ({
     }
   })
 
-  const controller = new AbortController()
-
   const submitQuery = async (message: MessageDraft, context?: string) => {
     await addNewMessage(ChatRole.USER, message)
+    controller = new AbortController()
     const options = {
       signal: controller.signal,
       callbacks: [{ handleLLMNewToken: updateAssistantMessage }],


### PR DESCRIPTION
`controller` is redefined each time the `useChatCompletion` component renders. This means `cancelRequest` will reference a different `controller` from `submitQuery`, resulting in the stop button to not work.

To fix, declare `controller` outside of the component, and reinstantiate a new `AbortController` in `submitQuery`. `cancelRequest` will reference the correct `controller`.