### PR TITLE
Fix error when storing embeddings in localStorage

### DIFF
--- a/.changeset/tasty-ravens-tickle.md
+++ b/.changeset/tasty-ravens-tickle.md
@@ -2,4 +2,12 @@
 "syncia": patch
 ---
 
-Fix error when storing embeddings in localStorage
+Fix storage quota exceeded error for embeddings
+
+Previously, the application would fail when trying to store large embeddings in localStorage due to quota limitations. This patch:
+
+- Transitions from localStorage to IndexedDB for storing embeddings
+- Implements new functions `saveToIndexedDB` and `getFromIndexedDB`
+- Resolves the "QuotaExceededError" when storing large datasets
+
+This change improves the application's ability to handle larger embeddings without storage constraints.

--- a/.changeset/tasty-ravens-tickle.md
+++ b/.changeset/tasty-ravens-tickle.md
@@ -1,0 +1,5 @@
+---
+"syncia": patch
+---
+
+Fix error when storing embeddings in localStorage

--- a/src/hooks/useStorage.ts
+++ b/src/hooks/useStorage.ts
@@ -104,3 +104,69 @@ export async function setStorage<T>(
     return false
   }
 }
+
+/**
+ * Function to save data to IndexedDB
+ */
+export const saveToIndexedDB = async (key: string, data: any) => {
+  return new Promise<void>((resolve, reject) => {
+    const request = indexedDB.open('SynciaDB', 1)
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      db.createObjectStore('embeddings')
+    }
+
+    request.onsuccess = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      const transaction = db.transaction('embeddings', 'readwrite')
+      const store = transaction.objectStore('embeddings')
+      store.put(data, key)
+
+      transaction.oncomplete = () => {
+        resolve()
+      }
+
+      transaction.onerror = (event) => {
+        reject(event)
+      }
+    }
+
+    request.onerror = (event) => {
+      reject(event)
+    }
+  })
+}
+
+/**
+ * Function to retrieve data from IndexedDB
+ */
+export const getFromIndexedDB = async (key: string) => {
+  return new Promise<any>((resolve, reject) => {
+    const request = indexedDB.open('SynciaDB', 1)
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      db.createObjectStore('embeddings')
+    }
+
+    request.onsuccess = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      const transaction = db.transaction('embeddings', 'readonly')
+      const store = transaction.objectStore('embeddings')
+      const getRequest = store.get(key)
+
+      getRequest.onsuccess = () => {
+        resolve(getRequest.result)
+      }
+
+      getRequest.onerror = (event) => {
+        reject(event)
+      }
+    }
+
+    request.onerror = (event) => {
+      reject(event)
+    }
+  })
+}


### PR DESCRIPTION
Fixes #95

Update `getContextVectorStore` to use `IndexedDB` instead of `localStorage` for storing embeddings.

* **src/lib/getMatchedContent.ts**
  - Import `getFromIndexedDB` and `saveToIndexedDB` from `useStorage.ts`.
  - Replace `localStorage` usage with `IndexedDB` functions for storing and retrieving embeddings.

* **src/hooks/useStorage.ts**
  - Add `saveToIndexedDB` function to save data to `IndexedDB`.
  - Add `getFromIndexedDB` function to retrieve data from `IndexedDB`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Royal-lobster/Syncia/issues/95?shareId=d808cc6c-6db8-476b-a40d-41c5b2a7f968).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous functions for data storage and retrieval using IndexedDB, enhancing data management capabilities.
- **Improvements**
	- Updated the storage mechanism for vector data from local storage to IndexedDB, allowing for better handling of larger datasets.
- **Bug Fixes**
	- Resolved an error related to storing embeddings in local storage, ensuring successful data storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->